### PR TITLE
Fix variable name in app CMake

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,13 +1,13 @@
 file(
 	GLOB_RECURSE
-	EDITOR_SOURCE_FILES
+	APP_SOURCE_FILES
 	"src/*.cpp"
 	"src/*.h"
 )
 
 add_executable(app)
 
-target_sources(app PRIVATE ${EDITOR_SOURCE_FILES})
+target_sources(app PRIVATE ${APP_SOURCE_FILES})
 
 set_property(TARGET app PROPERTY CXX_STANDARD 20)
 set_property(TARGET app PROPERTY CXX_EXTENSIONS ON)


### PR DESCRIPTION
## Summary
- rename `EDITOR_SOURCE_FILES` to `APP_SOURCE_FILES`
- keep `app` target building the same

## Testing
- `cmake -S . -B build` *(fails: CMake 3.29.2 required)*
- `cmake --build build` *(fails: could not find CMAKE_PROJECT_NAME)*

------
https://chatgpt.com/codex/tasks/task_e_684880b20e288320b5261724d2976791